### PR TITLE
adjust postlight insights custom selectors

### DIFF
--- a/src/extractors/custom/postlight.com/index.js
+++ b/src/extractors/custom/postlight.com/index.js
@@ -22,7 +22,7 @@ export const PostlightComExtractor = {
   },
 
   content: {
-    selectors: ['article.body'],
+    selectors: ['main.post'],
 
     // Is there anything in the content you selected that needs transformed
     // before it's consumable content? E.g., unusual lazy loaded images
@@ -31,6 +31,10 @@ export const PostlightComExtractor = {
     // Is there anything that is in the result that shouldn't be?
     // The clean selectors will remove anything that matches from
     // the result
-    clean: ['section.pl-post-link'],
+    clean: [
+      'section.pl-post-link',
+      'aside',
+      'section.insights_featured_case_studies',
+    ],
   },
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue this addresses (if applicable).

Contributing Guide: https://github.com/postlight/parser/blob/master/CONTRIBUTING.md
-->

This PR addresses [this issue](https://github.com/postlight/parser/issues/706) by adjusting the selectors in Postlight.com's custom selector. I had to expand the main content's selector and then exclude a few elements from within it. That way the hero image gets pulled in as part of the content and can be displayed by the Reader.

Note that the Parser does successfully select the hero image and emit it to the Reader as the `lead_image_url`, but that the Reader does not make use of that field for anything. So there might be a bigger design/product question to explore there. This is a reasonable fix in the meantime.