### PR TITLE
Use `xdg-open` instead of `open` for opening preview files

### DIFF
--- a/preview
+++ b/preview
@@ -33,7 +33,22 @@ urls.map(url => {
 
     fs.writeFileSync(htmlFile, html)
     fs.writeFileSync(jsonFile, JSON.stringify(result))
-    execSync(`open ${jsonFile}`)
-    execSync(`open ${htmlFile}`)
+
+    var openCommand = null
+    switch (process.platform) {
+      case 'darwin':
+        openCommand = 'open'
+        break
+      case 'linux':
+        openCommand = 'xdg-open'
+        break
+      default:
+        console.log(`Open ${jsonFile} and ${htmlFile} to check the generated files.`)
+    }
+
+    if (openCommand) {
+      execSync(`${openCommand} ${jsonFile}`)
+      execSync(`${openCommand} ${htmlFile}`)
+    }
   })
 })


### PR DESCRIPTION
Motivation:

- When a user runs `./preview` script to preview the extraction result, the script executes the `open` command regardless of the current operating system. As a result, the command fails on Linux.

Modifications:

- Use `xdg-open` instead of `open` in Linux to open a file.
- Log a message in other operating systems.

Result:

- Preview files are open automatically as expected in Linux.