### PR TITLE
fix: 721 | custom extractor extend bug

### DIFF
--- a/src/extractors/root-extractor.js
+++ b/src/extractors/root-extractor.js
@@ -223,6 +223,10 @@ const RootExtractor = {
         content,
       };
     }
+    let extendedResults = {};
+    if (extractor.extend) {
+      extendedResults = selectExtendedTypes(extractor.extend, opts);
+    }
     const title = extractResult({ ...opts, type: 'title' });
     const date_published = extractResult({ ...opts, type: 'date_published' });
     const author = extractResult({ ...opts, type: 'author' });
@@ -246,11 +250,6 @@ const RootExtractor = {
       ...opts,
       type: 'url_and_domain',
     }) || { url: null, domain: null };
-
-    let extendedResults = {};
-    if (extractor.extend) {
-      extendedResults = selectExtendedTypes(extractor.extend, opts);
-    }
 
     return {
       title,


### PR DESCRIPTION
# #721

This PR solves the above issue by selecting extended types before nodes get removed/cleaned during content selection. 

**Before:**
- Adding extended types via the command line was functional, but adding via the API with `addExtractor` was producing null extended values when custom extractors lacked a `content` key. This is because `root-extractor.js` was executing `selectExtendedTypes` after content extraction, which involves the removal of various nodes in the DOM tree. Consequently, some extended types failed to appear.

**After:**
- After this PR, `selectExtendedTypes` executes before content fetching in order to traverse the DOM before cleaning.  